### PR TITLE
feat: add logos and avatars to testimonial cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -501,6 +501,29 @@
       display: block;
     }
 
+    .testimonial-logo {
+      display: block;
+      height: 36px;
+      width: auto;
+      margin-bottom: 0.75rem;
+      filter: grayscale(100%) brightness(1.2);
+      opacity: 0.85;
+    }
+
+    .testimonial-avatar {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 36px;
+      height: 36px;
+      border-radius: 50%;
+      background: linear-gradient(135deg, #0ea5e9, #2563eb);
+      color: #fff;
+      font-size: 0.75rem;
+      font-weight: 700;
+      margin-bottom: 0.75rem;
+    }
+
     /* ============================================================
        CTA / CONTACT SECTION
     ============================================================ */
@@ -1028,6 +1051,7 @@
 
         <!-- Testimonial 1: Sam W. -->
         <article class="card" role="listitem">
+          <div class="testimonial-avatar">SW</div>
           <span class="testimonial-quote" aria-hidden="true">"</span>
           <p class="testimonial-text">
             Working with Mouaz and his team is always a pleasure. Highly skilled, always
@@ -1038,6 +1062,7 @@
 
         <!-- Testimonial 2: Lei Q. -->
         <article class="card" role="listitem">
+          <div class="testimonial-avatar">LQ</div>
           <span class="testimonial-quote" aria-hidden="true">"</span>
           <p class="testimonial-text">
             Skillfield team always deliver their service beyond our expectation. Truly
@@ -1048,6 +1073,7 @@
 
         <!-- Testimonial 3: Jennifer C. -->
         <article class="card" role="listitem">
+          <div class="testimonial-avatar">JC</div>
           <span class="testimonial-quote" aria-hidden="true">"</span>
           <p class="testimonial-text">
             Extremely dedicated, conscientious and thorough. Well versed in their chosen
@@ -1058,6 +1084,7 @@
 
         <!-- Testimonial 4: NBN Co -->
         <article class="card" role="listitem">
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/a/a9/National_Broadband_Network.svg/200px-National_Broadband_Network.svg.png" alt="NBN Co" class="testimonial-logo">
           <span class="testimonial-quote" aria-hidden="true">"</span>
           <p class="testimonial-text">
             Skillfield delivered exceptional results for our network infrastructure. Their


### PR DESCRIPTION
## Summary
Add logo images to testimonial cards on the Skillfield landing page.

## Changes
- Add CSS for `.testimonial-logo` and `.testimonial-avatar`
- Individual testimonials (Sam W., Lei Q., Jennifer C.): circular avatars with initials
- NBN Co: company logo from Wikimedia Commons

## Acceptance Criteria
- [x] Logos added to testimonial cards
- [x] Design matches page styling
- [x] Branch + PR created