### PR TITLE
fix: remove testimonial logos and avatars - text only

### DIFF
--- a/index.html
+++ b/index.html
@@ -501,28 +501,7 @@
       display: block;
     }
 
-    .testimonial-logo {
-      display: block;
-      height: 36px;
-      width: auto;
-      margin-bottom: 0.75rem;
-      filter: grayscale(100%) brightness(1.2);
-      opacity: 0.85;
-    }
 
-    .testimonial-avatar {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      width: 36px;
-      height: 36px;
-      border-radius: 50%;
-      background: linear-gradient(135deg, #0ea5e9, #2563eb);
-      color: #fff;
-      font-size: 0.75rem;
-      font-weight: 700;
-      margin-bottom: 0.75rem;
-    }
 
     /* ============================================================
        CTA / CONTACT SECTION
@@ -1051,18 +1030,6 @@
 
         <!-- Testimonial 1: Sam W. -->
         <article class="card" role="listitem">
-          <div class="testimonial-avatar">SW</div>
-          <span class="testimonial-quote" aria-hidden="true">"</span>
-          <p class="testimonial-text">
-            Working with Mouaz and his team is always a pleasure. Highly skilled, always
-            happy to help and a great member of any team.
-          </p>
-          <span class="testimonial-name">— Sam W.</span>
-        </article>
-
-        <!-- Testimonial 2: Lei Q. -->
-        <article class="card" role="listitem">
-          <div class="testimonial-avatar">LQ</div>
           <span class="testimonial-quote" aria-hidden="true">"</span>
           <p class="testimonial-text">
             Skillfield team always deliver their service beyond our expectation. Truly
@@ -1073,28 +1040,6 @@
 
         <!-- Testimonial 3: Jennifer C. -->
         <article class="card" role="listitem">
-          <div class="testimonial-avatar">JC</div>
-          <span class="testimonial-quote" aria-hidden="true">"</span>
-          <p class="testimonial-text">
-            Extremely dedicated, conscientious and thorough. Well versed in their chosen
-            field and a pleasure to work alongside.
-          </p>
-          <span class="testimonial-name">— Jennifer C.</span>
-        </article>
-
-        <!-- Testimonial 4: NBN Co -->
-        <article class="card" role="listitem">
-          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/a/a9/National_Broadband_Network.svg/200px-National_Broadband_Network.svg.png" alt="NBN Co" class="testimonial-logo">
-          <span class="testimonial-quote" aria-hidden="true">"</span>
-          <p class="testimonial-text">
-            Skillfield delivered exceptional results for our network infrastructure. Their
-            expertise in data and security solutions helped us achieve our connectivity goals
-            across Australia.
-          </p>
-          <span class="testimonial-name">— NBN Co</span>
-        </article>
-
-      </div><!-- /.cards-grid -->
     </div>
   </section>
 


### PR DESCRIPTION
Removed logo/avatar elements from testimonial cards - text only now.