### PR TITLE
fix: replace hello@ with info@ (Closes #10)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1104,8 +1104,8 @@
         business problem and deploy winning solutions — from cyber security to AI and data services.
       </p>
 
-      <a href="mailto:hello@skillfield.com.au" class="btn-primary">
-        hello@skillfield.com.au
+      <a href="mailto:info@skillfield.com.au" class="btn-primary">
+        info@skillfield.com.au
       </a>
 
     </div>
@@ -1134,7 +1134,7 @@
         <!-- Meta / contact -->
         <div class="footer-meta">
           Melbourne, Australia ·
-          <a href="mailto:hello@skillfield.com.au">hello@skillfield.com.au</a>
+          <a href="mailto:info@skillfield.com.au">info@skillfield.com.au</a>
         </div>
 
       </div>


### PR DESCRIPTION
## Summary
Replace hello@skillfield.com.au with info@skillfield.com.au across all instances.

## Changes
- index.html: 3 instances replaced

## Acceptance Criteria
- [x] All instances of hello@ changed to info@
- [x] No other email addresses affected
- [x] PR created

Closes #10

OpenClaw