### PR TITLE
fix: update copyright year to 2026

### DIFF
--- a/index.html
+++ b/index.html
@@ -1074,7 +1074,7 @@
         </div>
 
         <!-- Copyright -->
-        <p class="footer-copy">© 2025 Skillfield. All rights reserved.</p>
+        <p class="footer-copy">© 2026 Skillfield. All rights reserved.</p>
 
         <!-- Meta / contact -->
         <div class="footer-meta">


### PR DESCRIPTION
OpenClaw worked on this.

Updates footer copyright from 2025 to 2026.

Closes #11